### PR TITLE
Add genome and feature group creation to Protein Structure grid

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,40 @@
+name: Tag Release
+on:
+  pull_request:
+    types: [closed]
+    branches: [alpha]
+
+jobs:
+  tag-release:
+    # Only run if PR was merged and branch name starts with release/v
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          # Extract version from branch name (release/vX.X.X -> vX.X.X)
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/release\///')
+          # Use PR title as tag message
+          git tag -a "$VERSION" -m "${{ github.event.pull_request.title }}"
+          git push origin "$VERSION"
+          echo "Created and pushed tag: $VERSION"
+
+      - name: Delete release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" || true
+          echo "Deleted branch: $BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 on:
   workflow_dispatch:
-    branches:
-      - alpha
     inputs:
       version_type:
         description: 'Version bump type'
@@ -22,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,14 +32,28 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version
+        id: bump
         run: |
           npm version ${{ inputs.version_type }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          git checkout -b release/v${VERSION}
           git add package.json package-lock.json
           git commit -m "Release v${VERSION}
 
           ${{ inputs.release_message }}"
-          git tag -a "v${VERSION}" -m "${{ inputs.release_message }}"
 
-      - name: Push changes
-        run: git push && git push --tags
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.bump.outputs.version }}
+          git push -u origin release/v${VERSION}
+          gh pr create --base alpha --head release/v${VERSION} \
+            --title "Release v${VERSION}" \
+            --body "## Release v${VERSION}
+
+          ${{ inputs.release_message }}
+
+          ---
+          *After merging, a tag will be created automatically.*"

--- a/app.js
+++ b/app.js
@@ -94,9 +94,11 @@ if (proxyConfig) {
 
   for (const prox of proxyConfig) {
     console.log(prox);
+    // Use https by default, but allow it to be disabled per-proxy
+    const useHttps = prox.https !== undefined ? prox.https : prox.site.startsWith('https://');
     app.use(prox.local, proxy(prox.site, {
       proxyReqPathResolver: req => req.originalUrl.replace(prox.local, ""),
-      https: true
+      https: useHttps
     }));
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3-web",
-  "version": "3.57.18",
+  "version": "3.57.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3-web",
-      "version": "3.57.18",
+      "version": "3.57.19",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.6.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3-web",
-  "version": "3.57.11",
+  "version": "3.57.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3-web",
-      "version": "3.57.11",
+      "version": "3.57.18",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "3.57.18",
+  "version": "3.57.19",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "3.57.17",
+  "version": "3.57.18",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",

--- a/public/js/p3/store/TranscriptomicsGeneMemoryStore.js
+++ b/public/js/p3/store/TranscriptomicsGeneMemoryStore.js
@@ -271,10 +271,14 @@ define([
       var wsExpIds,
         wsComparisonIds;
       if (wsExperiments.length > 0) {
-        wsExpIds = wsExperiments[0].replace('wsExpId=', '').split(',');
+        wsExpIds = wsExperiments[0].replace('wsExpId=', '').split(',').map(function(id) {
+          return decodeURIComponent(id);
+        });
       }
       if (wsComparisons.length > 0) {
-        wsComparisonIds = wsComparisons[0].replace('wsComparisonId=', '').split(',');
+        wsComparisonIds = wsComparisons[0].replace('wsComparisonId=', '').split(',').map(function(id) {
+          return decodeURIComponent(id);
+        });
       }
 
       // console.log(this.state.search, "wsExpIds: ", wsExpIds, "wsComparisonIds: ", wsComparisonIds);

--- a/public/js/p3/widget/GridContainer.js
+++ b/public/js/p3/widget/GridContainer.js
@@ -1516,7 +1516,7 @@ define([
           requireAuth: true,
           max: 10000,
           tooltip: 'Add selection to a new or existing group',
-          validContainerTypes: ['genome_data', 'sequence_data', 'feature_data', 'protein_data', 'transcriptomics_experiment_data', 'transcriptomics_gene_data', 'spgene_data']
+          validContainerTypes: ['genome_data', 'sequence_data', 'feature_data', 'protein_data', 'transcriptomics_experiment_data', 'transcriptomics_gene_data', 'spgene_data', 'structure_data']
         },
         function (selection, containerWidget) {
           var dlg = new Dialog({ title: 'Add selected items to group' });
@@ -1532,6 +1532,8 @@ define([
             type = 'feature_group';
           } else if (containerWidget.containerType == 'transcriptomics_experiment_data') {
             type = 'experiment_group';
+          } else if (containerWidget.containerType == 'structure_data') {
+            type = 'feature_group';
           }
 
           if (!type) {

--- a/public/js/p3/widget/SelectionToGroup.js
+++ b/public/js/p3/widget/SelectionToGroup.js
@@ -20,7 +20,8 @@ define([
     idType: null,
     inputType: null,
     conversionTypes: {
-      feature_data: [{ label: 'Feature', value: 'feature_group' }, { label: 'Genome', value: 'genome_group' }]
+      feature_data: [{ label: 'Feature', value: 'feature_group' }, { label: 'Genome', value: 'genome_group' }],
+      structure_data: [{ label: 'Feature', value: 'feature_group' }, { label: 'Genome', value: 'genome_group' }]
     },
     selectType: false,
     _setTypeAttr: function (t) {

--- a/public/js/p3/widget/WorkspaceExplorerView.js
+++ b/public/js/p3/widget/WorkspaceExplorerView.js
@@ -178,6 +178,10 @@ define([
           }
 
           objs.sort(function (a, b) {
+            // Always keep parentfolder at the top regardless of sort order
+            if (a.type === 'parentfolder') return -1;
+            if (b.type === 'parentfolder') return 1;
+
             var s = sort[0];
             if (s.descending) {
               return (a[s.attribute] < b[s.attribute]) ? 1 : -1;

--- a/public/js/p3/widget/WorkspaceGrid.js
+++ b/public/js/p3/widget/WorkspaceGrid.js
@@ -285,6 +285,39 @@ define([
       // see WorkspaceExplorerView.listWorkspaceContents for sorting
       _self.set('sort', [{ attribute: 'name', descending: false }] );
 
+      // Override dgrid's sort to keep parentfolder at top
+      aspect.around(_self, 'renderArray', function (originalRenderArray) {
+        return function (results) {
+          // If results is an array, sort it with parentfolder pinned to top
+          if (Array.isArray(results)) {
+            var sort = _self.get('sort');
+            if (sort && sort.length > 0) {
+              results = results.slice().sort(function (a, b) {
+                // Always keep parentfolder at the top
+                if (a.type === 'parentfolder') return -1;
+                if (b.type === 'parentfolder') return 1;
+
+                var s = sort[0];
+                var aVal = a[s.attribute];
+                var bVal = b[s.attribute];
+                // Handle undefined/null values
+                if (aVal == null) aVal = '';
+                if (bVal == null) bVal = '';
+                // Case-insensitive string comparison
+                if (typeof aVal === 'string') aVal = aVal.toLowerCase();
+                if (typeof bVal === 'string') bVal = bVal.toLowerCase();
+
+                if (s.descending) {
+                  return (aVal < bVal) ? 1 : (aVal > bVal) ? -1 : 0;
+                }
+                return (aVal > bVal) ? 1 : (aVal < bVal) ? -1 : 0;
+              });
+            }
+          }
+          return originalRenderArray.call(this, results);
+        };
+      });
+
       this.inherited(arguments);
       this._started = true;
     },


### PR DESCRIPTION
## Summary
- Add `structure_data` to AddGroup action validContainerTypes in GridContainer.js
- Add `structure_data` type handling to create feature groups by default
- Add `structure_data` to conversionTypes in SelectionToGroup.js to enable dropdown selection between Feature and Genome groups

This allows users viewing the Structures tab on taxonomy pages to:
1. Select protein structures in the grid
2. Click the GROUP icon in the action bar
3. Choose whether to create a Genome Group or Feature Group
4. Save the group to their workspace

## ⚠️ Important: Do Not Merge Yet

**This PR should NOT be merged until the corresponding Data API fixes are installed.**

The Data API changes add access control filtering for `protein_structure` queries using a Solr cross-collection join on the genome collection. Without those changes, protein structures from private genomes may be exposed to unauthorized users.

## Test plan
- [ ] Navigate to a taxonomy page (e.g., /view/Taxonomy/1773#view_tab=structures)
- [ ] Select one or more protein structures in the grid
- [ ] Verify the GROUP icon appears in the green action bar
- [ ] Click GROUP icon and verify dialog shows "Group Type" dropdown with "Feature" and "Genome" options
- [ ] Test creating both Feature and Genome groups
- [ ] Verify groups are saved correctly to workspace

🤖 Generated with [Claude Code](https://claude.com/code)