### PR TITLE
Fix overlapping domains in visualization

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,40 @@
+name: Tag Release
+on:
+  pull_request:
+    types: [closed]
+    branches: [alpha]
+
+jobs:
+  tag-release:
+    # Only run if PR was merged and branch name starts with release/v
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: alpha
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          # Extract version from branch name (release/vX.X.X -> vX.X.X)
+          VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/release\///')
+          # Use PR title as tag message
+          git tag -a "$VERSION" -m "${{ github.event.pull_request.title }}"
+          git push origin "$VERSION"
+          echo "Created and pushed tag: $VERSION"
+
+      - name: Delete release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" || true
+          echo "Deleted branch: $BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 on:
   workflow_dispatch:
-    branches:
-      - alpha
     inputs:
       version_type:
         description: 'Version bump type'
@@ -22,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,14 +32,28 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version
+        id: bump
         run: |
           npm version ${{ inputs.version_type }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          git checkout -b release/v${VERSION}
           git add package.json package-lock.json
           git commit -m "Release v${VERSION}
 
           ${{ inputs.release_message }}"
-          git tag -a "v${VERSION}" -m "${{ inputs.release_message }}"
 
-      - name: Push changes
-        run: git push && git push --tags
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.bump.outputs.version }}
+          git push -u origin release/v${VERSION}
+          gh pr create --base alpha --head release/v${VERSION} \
+            --title "Release v${VERSION}" \
+            --body "## Release v${VERSION}
+
+          ${{ inputs.release_message }}
+
+          ---
+          *After merging, a tag will be created automatically.*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3-web",
-  "version": "3.57.18",
+  "version": "3.57.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3-web",
-      "version": "3.57.18",
+      "version": "3.57.19",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.6.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "p3-web",
-  "version": "3.57.11",
+  "version": "3.57.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "p3-web",
-      "version": "3.57.11",
+      "version": "3.57.18",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "3.57.18",
+  "version": "3.57.19",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "3.57.17",
+  "version": "3.57.18",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",

--- a/public/js/p3/resources/domain-viewer.css
+++ b/public/js/p3/resources/domain-viewer.css
@@ -1,0 +1,251 @@
+/* Domain Viewer Styles */
+
+/* Panel Container */
+.domain-visualization-panel {
+  background: #ffffff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  /* Ensure proper sizing within BorderContainer */
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+/* Override dijit ContentPane padding */
+.domain-visualization-panel.dijitContentPane {
+  padding: 0;
+}
+
+/* Adjust panel to align with grid (accounting for right panels) */
+.GridContainer > .domain-visualization-panel {
+  /* The right panels are: selectionActionBar (56px) + itemDetailPanel (250px) + splitter (~5px) = ~311px */
+  margin-right: 0;
+}
+
+.domain-visualization-panel.collapsed .domain-visualization-viewer {
+  display: none;
+}
+
+/* Header */
+.domain-visualization-header {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+  border-radius: 4px 4px 0 0;
+}
+
+.domain-visualization-panel.collapsed .domain-visualization-header {
+  border-bottom: none;
+  border-radius: 4px;
+}
+
+.domain-visualization-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+  margin-right: 8px;
+}
+
+.domain-visualization-count {
+  font-size: 12px;
+  color: #666;
+  flex-grow: 1;
+}
+
+.domain-visualization-toggle {
+  background: transparent;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 4px 8px;
+  cursor: pointer;
+  color: #666;
+  transition: all 0.2s ease;
+}
+
+.domain-visualization-toggle:hover {
+  background: #e0e0e0;
+  border-color: #999;
+  color: #333;
+}
+
+.domain-visualization-toggle:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(83, 117, 185, 0.3);
+}
+
+/* Viewer Container */
+.domain-visualization-viewer {
+  padding: 10px;
+  min-height: 100px;
+}
+
+.domain-viewer-chart {
+  width: 100%;
+}
+
+.domain-viewer-svg {
+  display: block;
+  width: 100%;
+}
+
+/* Empty State */
+.domain-viewer-empty {
+  font-size: 14px;
+  fill: #999;
+  font-style: italic;
+}
+
+/* Backbone */
+.domain-viewer-backbone polyline {
+  stroke: #333;
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.domain-viewer-position-label {
+  font-size: 11px;
+  fill: #666;
+  font-family: 'Roboto', 'Open Sans', sans-serif;
+}
+
+.domain-viewer-title-label {
+  font-size: 12px;
+  fill: #333;
+  font-weight: 500;
+  font-family: 'Roboto', 'Open Sans', sans-serif;
+}
+
+/* Domain Rectangles */
+.domain-viewer-domain {
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.domain-viewer-domain:hover {
+  opacity: 0.9;
+}
+
+.domain-viewer-domain rect {
+  transition: stroke-width 0.15s ease;
+}
+
+.domain-viewer-domain-label {
+  font-size: 10px;
+  fill: #333;
+  font-family: 'Roboto', 'Open Sans', sans-serif;
+  pointer-events: none;
+  text-shadow: 0 0 2px rgba(255, 255, 255, 0.8);
+}
+
+/* Legend */
+.domain-viewer-legend {
+  font-family: 'Roboto', 'Open Sans', sans-serif;
+}
+
+.domain-viewer-legend-text {
+  font-size: 11px;
+  fill: #555;
+}
+
+/* Tooltip */
+.domain-tooltip {
+  position: absolute;
+  background: rgba(40, 40, 40, 0.95);
+  color: #fff;
+  padding: 10px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: 'Roboto', 'Open Sans', sans-serif;
+  line-height: 1.5;
+  max-width: 350px;
+  z-index: 10000;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.domain-tooltip strong {
+  display: block;
+  font-size: 13px;
+  margin-bottom: 4px;
+  color: #fff;
+}
+
+.domain-tooltip-source {
+  color: #8dd3c7;
+  font-weight: 500;
+}
+
+.domain-tooltip-position,
+.domain-tooltip-length,
+.domain-tooltip-evalue {
+  color: #ddd;
+}
+
+.domain-tooltip-link {
+  color: #80b1d3;
+  font-style: italic;
+  margin-top: 4px;
+  display: block;
+}
+
+/* Selection Highlight */
+.domain-viewer-domain.selected rect {
+  stroke-width: 3px;
+}
+
+.domain-viewer-domain.hovered rect {
+  stroke-width: 2px;
+}
+
+/* Track Styling */
+.domain-viewer-track {
+  /* Track group styling if needed */
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+  .domain-visualization-header {
+    padding: 6px 10px;
+  }
+
+  .domain-visualization-title {
+    font-size: 13px;
+  }
+
+  .domain-visualization-count {
+    font-size: 11px;
+  }
+
+  .domain-viewer-position-label,
+  .domain-viewer-legend-text {
+    font-size: 10px;
+  }
+
+  .domain-viewer-domain-label {
+    font-size: 9px;
+  }
+
+  .domain-tooltip {
+    font-size: 11px;
+    max-width: 280px;
+  }
+}
+
+/* Print Styles */
+@media print {
+  .domain-visualization-toggle {
+    display: none;
+  }
+
+  .domain-visualization-panel {
+    box-shadow: none;
+    border: 1px solid #ccc;
+  }
+
+  .domain-tooltip {
+    display: none !important;
+  }
+}

--- a/public/js/p3/resources/p3.css
+++ b/public/js/p3/resources/p3.css
@@ -32,6 +32,7 @@
 @import url("./D3VerticalBarChart.css");
 @import url("./D3StackedAreaChart.css");
 @import url("./D3BarLineChart.css");
+@import url("./domain-viewer.css");
 @import url("../../cytoscape-context-menus/cytoscape-context-menus.css");
 @import url("./archaeopteryx/jquery-ui.css");
 

--- a/public/js/p3/store/TranscriptomicsGeneMemoryStore.js
+++ b/public/js/p3/store/TranscriptomicsGeneMemoryStore.js
@@ -271,10 +271,14 @@ define([
       var wsExpIds,
         wsComparisonIds;
       if (wsExperiments.length > 0) {
-        wsExpIds = wsExperiments[0].replace('wsExpId=', '').split(',');
+        wsExpIds = wsExperiments[0].replace('wsExpId=', '').split(',').map(function(id) {
+          return decodeURIComponent(id);
+        });
       }
       if (wsComparisons.length > 0) {
-        wsComparisonIds = wsComparisons[0].replace('wsComparisonId=', '').split(',');
+        wsComparisonIds = wsComparisons[0].replace('wsComparisonId=', '').split(',').map(function(id) {
+          return decodeURIComponent(id);
+        });
       }
 
       // console.log(this.state.search, "wsExpIds: ", wsExpIds, "wsComparisonIds: ", wsComparisonIds);

--- a/public/js/p3/widget/ProteinFeaturesGrid.js
+++ b/public/js/p3/widget/ProteinFeaturesGrid.js
@@ -1,10 +1,12 @@
 define([
   'dojo/_base/declare', 'dijit/layout/BorderContainer', 'dojo/on',
   'dojo/dom-class', 'dijit/layout/ContentPane', 'dojo/dom-construct',
+  'dojo/topic',
   './PageGrid', './formatter', '../store/ProteinFeaturesJsonRest', './GridSelector'
 ], function (
   declare, BorderContainer, on,
   domClass, ContentPane, domConstruct,
+  Topic,
   Grid, formatter, Store, selector
 ) {
 
@@ -62,6 +64,22 @@ define([
         });
       });
 
+      // Row hover event for domain visualization sync
+      this.on('.dgrid-content .dgrid-row:mouseover', function (evt) {
+        var row = _self.row(evt);
+        if (row && row.data) {
+          Topic.publish('/domainGrid/hover', {
+            id: row.data.id,
+            domain: row.data
+          });
+        }
+      });
+
+      // Row mouseout to clear hover
+      this.on('.dgrid-content .dgrid-row:mouseout', function (evt) {
+        Topic.publish('/domainGrid/hover', { id: null });
+      });
+
       this.on('dgrid-select', function (evt) {
         console.log('dgrid-select: ', evt);
         var newEvt = {
@@ -72,6 +90,10 @@ define([
           cancelable: true
         };
         on.emit(_self.domNode, 'select', newEvt);
+
+        // Publish selection to domain visualization
+        var selectedIds = Object.keys(evt.grid.selection);
+        Topic.publish('/domainGrid/select', { ids: selectedIds });
       });
       this.on('dgrid-deselect', function (evt) {
         console.log('dgrid-select');
@@ -83,7 +105,17 @@ define([
           cancelable: true
         };
         on.emit(_self.domNode, 'deselect', newEvt);
+
+        // Publish updated selection to domain visualization
+        var selectedIds = Object.keys(evt.grid.selection);
+        Topic.publish('/domainGrid/select', { ids: selectedIds });
       });
+
+      // Subscribe to visualization selection events to highlight rows in grid
+      Topic.subscribe('/domainViewer/hover', function (data) {
+        // Could add row highlighting here if needed
+      });
+
       this.inherited(arguments);
       this.refresh();
     }

--- a/public/js/p3/widget/ProteinFeaturesGridContainer.js
+++ b/public/js/p3/widget/ProteinFeaturesGridContainer.js
@@ -1,14 +1,17 @@
 define([
-  'dojo/_base/declare', 'dojo/on', 'dojo/dom-construct',
+  'dojo/_base/declare', 'dojo/on', 'dojo/dom-construct', 'dojo/topic',
   'dijit/popup', 'dijit/TooltipDialog',
   './ProteinFeaturesGrid', './AdvancedSearchFields', './GridContainer',
-  '../util/PathJoin'
+  '../util/PathJoin',
+  './viewer/DomainVisualizationPanel',
+  'xstyle/css!../resources/domain-viewer.css'
 
 ], function (
-  declare, on, domConstruct,
+  declare, on, domConstruct, Topic,
   popup, TooltipDialog,
   ProteinFeaturesGrid, AdvancedSearchFields, GridContainer,
-  PathJoin
+  PathJoin,
+  DomainVisualizationPanel
 ) {
 
   const dfc = '<div>Download Table As...</div><div class="wsActionTooltip" rel="text/tsv">Text</div><div class="wsActionTooltip" rel="text/csv">CSV</div><div class="wsActionTooltip" rel="application/vnd.openxmlformats">Excel</div>';
@@ -29,7 +32,179 @@ define([
     dataModel: 'protein_feature',
     primaryKey: 'id',
     defaultFilter: '',
-    tooltip: 'The “Domains and Motifs” tab shows predicted domains and motifs for proteins from reference and representative genomes associated with the current view.',
+    tooltip: 'The "Domains and Motifs" tab shows predicted domains and motifs for proteins from reference and representative genomes associated with the current view.',
+
+    // Use sidebar design so right panels extend to top, and visualization aligns with grid
+    design: 'sidebar',
+
+    // Visualization panel (only created for single-feature view)
+    visualizationPanel: null,
+    // Flag to track if this is a single-feature context
+    isSingleFeatureView: false,
+
+    postCreate: function () {
+      this.inherited(arguments);
+
+      // Subscribe to grid data refresh events to update visualization
+      this._setupVisualizationSync();
+    },
+
+    /**
+     * Check if the current state represents a single-feature view
+     * @param {Object} state - The current state object
+     * @returns {boolean} True if viewing domains for a single feature
+     */
+    _isSingleFeatureState: function (state) {
+      if (!state || !state.search) {
+        return false;
+      }
+      // Check if the search query is for a single feature_id
+      // Pattern: eq(feature_id,xxx) where xxx is a single ID (not a list)
+      var search = state.search;
+      var singleFeaturePattern = /^eq\(feature_id,([^,)]+)\)$/;
+      return singleFeaturePattern.test(search);
+    },
+
+    /**
+     * Override onFirstView - don't create visualization panel here,
+     * wait until we know if it's a single-feature view
+     */
+    onFirstView: function () {
+      // Call parent to create the grid
+      this.inherited(arguments);
+    },
+
+    /**
+     * Create the domain visualization panel (only for single-feature view)
+     */
+    _createVisualizationPanel: function () {
+      if (this.visualizationPanel) {
+        return; // Already created
+      }
+
+      // Create the visualization panel as a ContentPane with region: 'top'
+      // layoutPriority 5 is higher than the right panels (3 and 4), so the
+      // visualization will be positioned after them (closer to center),
+      // giving it the same width as the grid
+      this.visualizationPanel = new DomainVisualizationPanel({
+        title: 'Domain Map',
+        region: 'top',
+        splitter: false,
+        layoutPriority: 5
+      });
+
+      // Add as child of this BorderContainer
+      this.addChild(this.visualizationPanel);
+
+      // Trigger resize to adjust layout
+      this.resize();
+    },
+
+    /**
+     * Remove the visualization panel if it exists
+     */
+    _removeVisualizationPanel: function () {
+      if (this.visualizationPanel) {
+        this.removeChild(this.visualizationPanel);
+        this.visualizationPanel.destroyRecursive();
+        this.visualizationPanel = null;
+        this.resize();
+      }
+    },
+
+    /**
+     * Set up synchronization between grid and visualization
+     */
+    _setupVisualizationSync: function () {
+      var self = this;
+
+      // Listen for grid refresh/data load events
+      Topic.subscribe('/domainViewer/select', function (data) {
+        if (data && data.domain && self.grid) {
+          // Find the row in the grid and select it
+          var id = data.domain.id;
+          if (id) {
+            self.grid.select(id);
+          }
+        }
+      });
+    },
+
+    /**
+     * Update visualization when grid data changes
+     */
+    _updateVisualization: function () {
+      var self = this;
+
+      if (!this.visualizationPanel || !this.grid) {
+        return;
+      }
+
+      // Get visible data from the grid
+      var domains = [];
+      var proteinLength = 0;
+
+      // Try to get data from the grid store
+      if (this.grid.store) {
+        var query = this.grid.get('query');
+        this.grid.store.query(query, { count: 1000 }).then(function (results) {
+          if (results && results.length > 0) {
+            domains = results;
+            // Estimate protein length from max domain end
+            domains.forEach(function (d) {
+              if (d.end && d.end > proteinLength) {
+                proteinLength = d.end;
+              }
+            });
+            // Add some padding
+            proteinLength = Math.ceil(proteinLength * 1.05);
+
+            // Update the visualization panel
+            self.visualizationPanel.setData(domains, proteinLength);
+
+            // Publish data loaded event
+            Topic.publish('/domainGrid/dataLoaded', {
+              domains: domains,
+              proteinLength: proteinLength
+            });
+          } else {
+            // No domains found
+            self.visualizationPanel.setData([], 0);
+          }
+        });
+      }
+    },
+
+    /**
+     * Override onSetState to conditionally show visualization
+     */
+    onSetState: function (attr, oldState, state) {
+      // Call parent's onSetState first
+      this.inherited(arguments);
+
+      var self = this;
+      var isSingleFeature = this._isSingleFeatureState(state);
+
+      if (isSingleFeature !== this.isSingleFeatureView) {
+        this.isSingleFeatureView = isSingleFeature;
+
+        if (isSingleFeature) {
+          // Create visualization panel for single-feature view
+          this._createVisualizationPanel();
+        } else {
+          // Remove visualization panel for multi-feature view
+          this._removeVisualizationPanel();
+        }
+      }
+
+      // Update visualization after a short delay to allow grid to update
+      if (this.visualizationPanel && state && isSingleFeature) {
+        setTimeout(function () {
+          self._updateVisualization();
+        }, 500);
+      }
+    },
+
     getFilterPanel: function (opts) {
 
     },

--- a/public/js/p3/widget/WorkspaceExplorerView.js
+++ b/public/js/p3/widget/WorkspaceExplorerView.js
@@ -178,6 +178,10 @@ define([
           }
 
           objs.sort(function (a, b) {
+            // Always keep parentfolder at the top regardless of sort order
+            if (a.type === 'parentfolder') return -1;
+            if (b.type === 'parentfolder') return 1;
+
             var s = sort[0];
             if (s.descending) {
               return (a[s.attribute] < b[s.attribute]) ? 1 : -1;

--- a/public/js/p3/widget/WorkspaceGrid.js
+++ b/public/js/p3/widget/WorkspaceGrid.js
@@ -285,6 +285,39 @@ define([
       // see WorkspaceExplorerView.listWorkspaceContents for sorting
       _self.set('sort', [{ attribute: 'name', descending: false }] );
 
+      // Override dgrid's sort to keep parentfolder at top
+      aspect.around(_self, 'renderArray', function (originalRenderArray) {
+        return function (results) {
+          // If results is an array, sort it with parentfolder pinned to top
+          if (Array.isArray(results)) {
+            var sort = _self.get('sort');
+            if (sort && sort.length > 0) {
+              results = results.slice().sort(function (a, b) {
+                // Always keep parentfolder at the top
+                if (a.type === 'parentfolder') return -1;
+                if (b.type === 'parentfolder') return 1;
+
+                var s = sort[0];
+                var aVal = a[s.attribute];
+                var bVal = b[s.attribute];
+                // Handle undefined/null values
+                if (aVal == null) aVal = '';
+                if (bVal == null) bVal = '';
+                // Case-insensitive string comparison
+                if (typeof aVal === 'string') aVal = aVal.toLowerCase();
+                if (typeof bVal === 'string') bVal = bVal.toLowerCase();
+
+                if (s.descending) {
+                  return (aVal < bVal) ? 1 : (aVal > bVal) ? -1 : 0;
+                }
+                return (aVal > bVal) ? 1 : (aVal < bVal) ? -1 : 0;
+              });
+            }
+          }
+          return originalRenderArray.call(this, results);
+        };
+      });
+
       this.inherited(arguments);
       this._started = true;
     },

--- a/public/js/p3/widget/viewer/D3DomainViewer.js
+++ b/public/js/p3/widget/viewer/D3DomainViewer.js
@@ -12,14 +12,13 @@ define([
 
   return declare([], {
     // Configuration
-    trackHeight: 24,
-    trackPadding: 4,
+    trackHeight: 20,
+    trackPadding: 3,
     backboneHeight: 10,
     headerHeight: 30,
     legendHeight: 25,
     minDomainWidth: 3,
-    maxTracks: 8,
-    overlapPadding: 5,
+    maxTracks: 15,
 
     // State
     domains: null,
@@ -183,23 +182,30 @@ define([
       var self = this;
       var tracks = [];
 
-      // Sort domains by start position
+      // Sort domains by start position, then by end position (shorter domains first)
       var sortedDomains = domains.slice().sort(function (a, b) {
-        return (a.start || 0) - (b.start || 0);
+        var startDiff = (a.start || 0) - (b.start || 0);
+        if (startDiff !== 0) {
+          return startDiff;
+        }
+        // If same start, shorter domain first
+        return (a.end || 0) - (b.end || 0);
       });
 
-      tracks.push({ domains: [], maxEnd: 0 });
+      tracks.push({ domains: [], maxEnd: -1 });
 
       sortedDomains.forEach(function (domain) {
         var start = domain.start || 0;
         var end = domain.end || start;
         var placed = false;
 
-        // Try to find a track where this domain fits
+        // Try to find a track where this domain fits (no overlap)
+        // A domain fits if its start position is greater than the track's maxEnd
+        // (i.e., the domain starts after all existing domains in the track end)
         for (var i = 0; i < tracks.length; i++) {
           var track = tracks[i];
-          if (start > track.maxEnd + self.overlapPadding) {
-            // Domain fits in this track
+          if (start > track.maxEnd) {
+            // Domain fits in this track - no overlap
             track.domains.push(domain);
             track.maxEnd = end;
             domain._track = i;

--- a/public/js/p3/widget/viewer/D3DomainViewer.js
+++ b/public/js/p3/widget/viewer/D3DomainViewer.js
@@ -1,0 +1,558 @@
+define([
+  'dojo/_base/declare', 'dojo/_base/lang',
+  'dojo/dom', 'dojo/dom-class', 'dojo/dom-construct', 'dojo/dom-style', 'dojo/topic',
+  'd3/d3',
+  './DomainColorScheme'
+], function (
+  declare, lang,
+  dom, domClass, domConstruct, domStyle, Topic,
+  d3,
+  DomainColorScheme
+) {
+
+  return declare([], {
+    // Configuration
+    trackHeight: 24,
+    trackPadding: 4,
+    backboneHeight: 10,
+    headerHeight: 30,
+    legendHeight: 25,
+    minDomainWidth: 3,
+    maxTracks: 8,
+    overlapPadding: 5,
+
+    // State
+    domains: null,
+    proteinLength: 0,
+    selectedIds: null,
+    hoveredId: null,
+
+    constructor: function (args) {
+      lang.mixin(this, args || {});
+      this.selectedIds = {};
+    },
+
+    /**
+     * Initialize the viewer with a target DOM node
+     * @param {DOMNode|string} target - Container element or ID
+     */
+    init: function (target) {
+      this.containerNode = typeof target === 'string' ? dom.byId(target) : target;
+      this.node = domConstruct.place('<div class="domain-viewer-chart"></div>', this.containerNode, 'only');
+
+      this.nodeWidth = parseInt(domStyle.get(this.node, 'width')) || 800;
+
+      this.canvas = d3.select(this.node)
+        .append('svg')
+        .attr('class', 'domain-viewer-svg')
+        .attr('preserveAspectRatio', 'xMidYMid meet');
+
+      // Create or reuse tooltip
+      if (d3.select('div.domain-tooltip')[0][0]) {
+        this.tooltipLayer = d3.select('div.domain-tooltip');
+      } else {
+        this.tooltipLayer = d3.select('body').append('div')
+          .attr('class', 'domain-tooltip')
+          .style('opacity', 0)
+          .style('position', 'absolute')
+          .style('pointer-events', 'none');
+      }
+
+      // Subscribe to grid events for synchronization
+      this._subscribeToGridEvents();
+    },
+
+    /**
+     * Subscribe to grid selection/hover events
+     */
+    _subscribeToGridEvents: function () {
+      var self = this;
+
+      Topic.subscribe('/domainGrid/select', function (data) {
+        if (data && data.ids) {
+          self.setSelection(data.ids);
+        }
+      });
+
+      Topic.subscribe('/domainGrid/hover', function (data) {
+        if (data && data.id) {
+          self.setHover(data.id);
+        } else {
+          self.clearHover();
+        }
+      });
+    },
+
+    /**
+     * Set the data and render the visualization
+     * @param {Array} domains - Array of domain objects
+     * @param {number} proteinLength - Length of the protein sequence
+     */
+    setData: function (domains, proteinLength) {
+      this.domains = domains || [];
+      this.proteinLength = proteinLength || this._estimateProteinLength(domains);
+      this.selectedIds = {};
+      this.hoveredId = null;
+
+      if (this.domains.length > 0) {
+        this.render();
+      } else {
+        this._renderEmptyState();
+      }
+    },
+
+    /**
+     * Estimate protein length from domain data when not provided
+     */
+    _estimateProteinLength: function (domains) {
+      if (!domains || domains.length === 0) {
+        return 100;
+      }
+      var maxEnd = 0;
+      domains.forEach(function (d) {
+        if (d.end && d.end > maxEnd) {
+          maxEnd = d.end;
+        }
+      });
+      // Add 5% padding
+      return Math.ceil(maxEnd * 1.05);
+    },
+
+    /**
+     * Render empty state message
+     */
+    _renderEmptyState: function () {
+      this.canvas.selectAll('*').remove();
+
+      var height = 60;
+      this.canvas
+        .attr('viewBox', '0 0 ' + this.nodeWidth + ' ' + height)
+        .attr('width', '100%')
+        .attr('height', height);
+
+      this.canvas.append('text')
+        .attr('x', this.nodeWidth / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('class', 'domain-viewer-empty')
+        .text('No domains to display');
+    },
+
+    /**
+     * Main render function
+     */
+    render: function () {
+      var self = this;
+      this.canvas.selectAll('*').remove();
+
+      // Update node width in case of resize
+      this.nodeWidth = parseInt(domStyle.get(this.node, 'width')) || 800;
+
+      // Assign domains to tracks to handle overlaps
+      var tracks = this._assignTracks(this.domains);
+      var numTracks = Math.min(tracks.length, this.maxTracks);
+
+      // Calculate canvas dimensions
+      var canvasWidth = this.nodeWidth - 20; // padding
+      var canvasHeight = this.headerHeight +
+        this.backboneHeight +
+        (numTracks * (this.trackHeight + this.trackPadding)) +
+        this.legendHeight + 20;
+
+      // Set up viewBox for responsive sizing
+      this.canvas
+        .attr('viewBox', '-10 0 ' + (this.nodeWidth + 10) + ' ' + canvasHeight)
+        .attr('width', '100%')
+        .attr('height', canvasHeight);
+
+      // Create scale for mapping protein positions to pixels
+      this.xScale = d3.scale.linear()
+        .range([0, canvasWidth])
+        .domain([0, this.proteinLength]);
+
+      // Render components
+      this._renderBackbone(canvasWidth);
+      this._renderDomains(tracks, canvasWidth);
+      this._renderLegend(canvasWidth, canvasHeight);
+    },
+
+    /**
+     * Assign domains to tracks using greedy algorithm to avoid overlaps
+     */
+    _assignTracks: function (domains) {
+      var self = this;
+      var tracks = [];
+
+      // Sort domains by start position
+      var sortedDomains = domains.slice().sort(function (a, b) {
+        return (a.start || 0) - (b.start || 0);
+      });
+
+      tracks.push({ domains: [], maxEnd: 0 });
+
+      sortedDomains.forEach(function (domain) {
+        var start = domain.start || 0;
+        var end = domain.end || start;
+        var placed = false;
+
+        // Try to find a track where this domain fits
+        for (var i = 0; i < tracks.length; i++) {
+          var track = tracks[i];
+          if (start > track.maxEnd + self.overlapPadding) {
+            // Domain fits in this track
+            track.domains.push(domain);
+            track.maxEnd = end;
+            domain._track = i;
+            placed = true;
+            break;
+          }
+        }
+
+        // If no track found, create a new one (up to max)
+        if (!placed) {
+          if (tracks.length < self.maxTracks) {
+            var newTrack = { domains: [domain], maxEnd: end };
+            domain._track = tracks.length;
+            tracks.push(newTrack);
+          } else {
+            // Place in lowest track anyway (will overlap)
+            tracks[self.maxTracks - 1].domains.push(domain);
+            domain._track = self.maxTracks - 1;
+            tracks[self.maxTracks - 1].maxEnd = Math.max(tracks[self.maxTracks - 1].maxEnd, end);
+          }
+        }
+      });
+
+      return tracks;
+    },
+
+    /**
+     * Render the protein backbone (horizontal bar)
+     */
+    _renderBackbone: function (canvasWidth) {
+      var self = this;
+      var backboneY = this.headerHeight;
+
+      // Create backbone group
+      var backbone = this.canvas.append('g')
+        .attr('class', 'domain-viewer-backbone')
+        .attr('transform', 'translate(0, ' + backboneY + ')');
+
+      // Draw the backbone line with end caps
+      backbone.append('polyline')
+        .attr('points', lang.replace('0 -{0} 0 {0} 0 0 {1} 0 {1} {0} {1} -{0}',
+          [this.backboneHeight / 2, canvasWidth]))
+        .attr('fill', 'none')
+        .attr('stroke', '#333')
+        .attr('stroke-width', 1.5);
+
+      // Add position labels
+      backbone.append('text')
+        .attr('x', 0)
+        .attr('y', -this.backboneHeight - 2)
+        .attr('class', 'domain-viewer-position-label')
+        .text('1');
+
+      backbone.append('text')
+        .attr('x', canvasWidth)
+        .attr('y', -this.backboneHeight - 2)
+        .attr('text-anchor', 'end')
+        .attr('class', 'domain-viewer-position-label')
+        .text(this.proteinLength + ' aa');
+
+      // Add center label (protein accession if available)
+      backbone.append('text')
+        .attr('x', canvasWidth / 2)
+        .attr('y', -this.backboneHeight - 2)
+        .attr('text-anchor', 'middle')
+        .attr('class', 'domain-viewer-title-label')
+        .text('Protein Sequence');
+    },
+
+    /**
+     * Render domain rectangles
+     */
+    _renderDomains: function (tracks, canvasWidth) {
+      var self = this;
+      var domainStartY = this.headerHeight + this.backboneHeight + 5;
+
+      tracks.forEach(function (track, trackIndex) {
+        var trackY = domainStartY + trackIndex * (self.trackHeight + self.trackPadding);
+
+        var trackGroup = self.canvas.append('g')
+          .attr('class', 'domain-viewer-track')
+          .attr('transform', 'translate(0, ' + trackY + ')');
+
+        track.domains.forEach(function (domain) {
+          self._renderDomain(trackGroup, domain);
+        });
+      });
+    },
+
+    /**
+     * Render a single domain rectangle
+     */
+    _renderDomain: function (trackGroup, domain) {
+      var self = this;
+      var start = domain.start || 0;
+      var end = domain.end || start;
+
+      var x = this.xScale(start);
+      var width = Math.max(this.xScale(end) - x, this.minDomainWidth);
+      var color = DomainColorScheme.getSourceColor(domain.source);
+      var id = domain.id || (domain.source + '_' + domain.source_id + '_' + start);
+
+      var domainGroup = trackGroup.append('g')
+        .attr('class', 'domain-viewer-domain')
+        .attr('data-domain-id', id)
+        .attr('transform', 'translate(' + x + ', 0)');
+
+      // Main rectangle
+      var rect = domainGroup.append('rect')
+        .attr('width', width)
+        .attr('height', this.trackHeight)
+        .attr('rx', 3)
+        .attr('ry', 3)
+        .attr('fill', color)
+        .attr('stroke', DomainColorScheme.getDarkerShade(color, 20))
+        .attr('stroke-width', 1)
+        .attr('class', 'domain-rect');
+
+      // Add label if there's enough space
+      if (width > 40) {
+        var label = domain.source_id || domain.source || '';
+        if (label.length > Math.floor(width / 7)) {
+          label = label.substring(0, Math.floor(width / 7) - 2) + '...';
+        }
+
+        domainGroup.append('text')
+          .attr('x', width / 2)
+          .attr('y', this.trackHeight / 2 + 4)
+          .attr('text-anchor', 'middle')
+          .attr('class', 'domain-viewer-domain-label')
+          .text(label);
+      }
+
+      // Event handlers
+      domainGroup
+        .on('mouseover', function () {
+          self._onDomainMouseOver(domain, this);
+        })
+        .on('mouseout', function () {
+          self._onDomainMouseOut(domain, this);
+        })
+        .on('click', function () {
+          self._onDomainClick(domain);
+        });
+
+      // Store reference for selection updates
+      domain._element = domainGroup;
+    },
+
+    /**
+     * Handle domain mouseover
+     */
+    _onDomainMouseOver: function (domain, element) {
+      var self = this;
+
+      // Highlight the domain
+      d3.select(element).select('rect')
+        .attr('stroke-width', 2);
+
+      // Build tooltip content
+      var content = [];
+      if (domain.description) {
+        content.push('<strong>' + domain.description + '</strong>');
+      }
+      if (domain.source && domain.source_id) {
+        content.push('<span class="domain-tooltip-source">' + domain.source + ': ' + domain.source_id + '</span>');
+      }
+      content.push('<span class="domain-tooltip-position">Position: ' + (domain.start || '?') + ' - ' + (domain.end || '?') + '</span>');
+      if (domain.length) {
+        content.push('<span class="domain-tooltip-length">Length: ' + domain.length + ' aa</span>');
+      }
+      if (domain.e_value !== undefined && domain.e_value !== null) {
+        content.push('<span class="domain-tooltip-evalue">E-value: ' + domain.e_value + '</span>');
+      }
+
+      var externalUrl = DomainColorScheme.getExternalUrl(domain.source, domain.source_id);
+      if (externalUrl) {
+        content.push('<span class="domain-tooltip-link">Click to view in ' + domain.source + '</span>');
+      }
+
+      // Show tooltip
+      this.tooltipLayer
+        .html(content.join('<br>'))
+        .style('left', (d3.event.pageX + 10) + 'px')
+        .style('top', (d3.event.pageY - 10) + 'px')
+        .transition()
+        .duration(200)
+        .style('opacity', 0.95);
+
+      // Publish hover event for grid sync
+      Topic.publish('/domainViewer/hover', { id: domain.id, domain: domain });
+    },
+
+    /**
+     * Handle domain mouseout
+     */
+    _onDomainMouseOut: function (domain, element) {
+      // Remove highlight unless selected
+      var id = domain.id || (domain.source + '_' + domain.source_id + '_' + domain.start);
+      if (!this.selectedIds[id]) {
+        d3.select(element).select('rect')
+          .attr('stroke-width', 1);
+      }
+
+      // Hide tooltip
+      this.tooltipLayer
+        .transition()
+        .duration(500)
+        .style('opacity', 0);
+
+      // Publish hover clear event
+      Topic.publish('/domainViewer/hover', { id: null });
+    },
+
+    /**
+     * Handle domain click
+     */
+    _onDomainClick: function (domain) {
+      // Try to open external URL
+      var externalUrl = DomainColorScheme.getExternalUrl(domain.source, domain.source_id);
+      if (externalUrl) {
+        window.open(externalUrl, '_blank');
+      }
+
+      // Also publish selection event for grid sync
+      Topic.publish('/domainViewer/select', { ids: [domain.id], domain: domain });
+    },
+
+    /**
+     * Render color legend
+     */
+    _renderLegend: function (canvasWidth, canvasHeight) {
+      var self = this;
+      var sources = DomainColorScheme.getSourcesFromDomains(this.domains);
+
+      if (sources.length === 0) {
+        return;
+      }
+
+      var legendY = canvasHeight - this.legendHeight;
+      var legend = this.canvas.append('g')
+        .attr('class', 'domain-viewer-legend')
+        .attr('transform', 'translate(0, ' + legendY + ')');
+
+      var itemWidth = 100;
+      var maxItems = Math.floor(canvasWidth / itemWidth);
+      var displaySources = sources.slice(0, maxItems);
+
+      displaySources.forEach(function (source, i) {
+        var itemX = i * itemWidth;
+
+        var item = legend.append('g')
+          .attr('transform', 'translate(' + itemX + ', 0)');
+
+        item.append('rect')
+          .attr('width', 14)
+          .attr('height', 14)
+          .attr('rx', 2)
+          .attr('ry', 2)
+          .attr('fill', source.color);
+
+        item.append('text')
+          .attr('x', 18)
+          .attr('y', 11)
+          .attr('class', 'domain-viewer-legend-text')
+          .text(source.source);
+      });
+    },
+
+    /**
+     * Set selected domain IDs
+     * @param {Array|Object} ids - Array of IDs or object with ID keys
+     */
+    setSelection: function (ids) {
+      var self = this;
+
+      // Clear previous selection
+      this.canvas.selectAll('.domain-viewer-domain rect')
+        .attr('stroke-width', 1);
+
+      // Convert to object if array
+      if (Array.isArray(ids)) {
+        this.selectedIds = {};
+        ids.forEach(function (id) {
+          self.selectedIds[id] = true;
+        });
+      } else {
+        this.selectedIds = ids || {};
+      }
+
+      // Apply selection highlighting
+      this.canvas.selectAll('.domain-viewer-domain').each(function () {
+        var el = d3.select(this);
+        var id = el.attr('data-domain-id');
+        if (self.selectedIds[id]) {
+          el.select('rect').attr('stroke-width', 3);
+        }
+      });
+    },
+
+    /**
+     * Set hovered domain ID
+     */
+    setHover: function (id) {
+      this.hoveredId = id;
+      var self = this;
+
+      this.canvas.selectAll('.domain-viewer-domain').each(function () {
+        var el = d3.select(this);
+        var domainId = el.attr('data-domain-id');
+        if (domainId === id) {
+          el.select('rect').attr('stroke-width', 2);
+        } else if (!self.selectedIds[domainId]) {
+          el.select('rect').attr('stroke-width', 1);
+        }
+      });
+    },
+
+    /**
+     * Clear hover state
+     */
+    clearHover: function () {
+      var self = this;
+      this.hoveredId = null;
+
+      this.canvas.selectAll('.domain-viewer-domain').each(function () {
+        var el = d3.select(this);
+        var domainId = el.attr('data-domain-id');
+        if (!self.selectedIds[domainId]) {
+          el.select('rect').attr('stroke-width', 1);
+        }
+      });
+    },
+
+    /**
+     * Resize the viewer
+     */
+    resize: function () {
+      if (this.domains && this.domains.length > 0) {
+        this.render();
+      }
+    },
+
+    /**
+     * Destroy the viewer and clean up
+     */
+    destroy: function () {
+      if (this.canvas) {
+        this.canvas.selectAll('*').remove();
+      }
+      if (this.tooltipLayer) {
+        this.tooltipLayer.remove();
+      }
+    }
+  });
+});

--- a/public/js/p3/widget/viewer/D3DomainViewer.js
+++ b/public/js/p3/widget/viewer/D3DomainViewer.js
@@ -227,6 +227,22 @@ define([
     },
 
     /**
+     * Determine if a hex color is dark (for text contrast)
+     * Uses relative luminance calculation
+     * @param {string} hexColor - Hex color code (e.g., '#1e3cbe')
+     * @returns {boolean} True if the color is dark
+     */
+    _isColorDark: function (hexColor) {
+      var hex = hexColor.replace('#', '');
+      var r = parseInt(hex.substring(0, 2), 16);
+      var g = parseInt(hex.substring(2, 4), 16);
+      var b = parseInt(hex.substring(4, 6), 16);
+      // Calculate relative luminance (ITU-R BT.709)
+      var luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+      return luminance < 0.5;
+    },
+
+    /**
      * Render the protein backbone (horizontal bar)
      */
     _renderBackbone: function (canvasWidth) {
@@ -325,11 +341,15 @@ define([
           label = label.substring(0, Math.floor(width / 7) - 2) + '...';
         }
 
+        // Determine text color based on background brightness
+        var textColor = this._isColorDark(color) ? '#ffffff' : '#333333';
+
         domainGroup.append('text')
           .attr('x', width / 2)
           .attr('y', this.trackHeight / 2 + 4)
           .attr('text-anchor', 'middle')
           .attr('class', 'domain-viewer-domain-label')
+          .attr('fill', textColor)
           .text(label);
       }
 

--- a/public/js/p3/widget/viewer/DomainColorScheme.js
+++ b/public/js/p3/widget/viewer/DomainColorScheme.js
@@ -1,0 +1,188 @@
+define([], function () {
+  /**
+   * DomainColorScheme - Colorblind-accessible color palette for domain sources
+   * and utility functions for color manipulation and external URL generation.
+   */
+
+  // Colorblind-accessible palette for domain sources
+  var sourceColors = {
+    'CDD': '#66c2a5',        // Teal
+    'InterPro': '#fc8d62',   // Orange
+    'Pfam': '#8da0cb',       // Blue-purple
+    'TIGRFAM': '#e78ac3',    // Pink
+    'SMART': '#a6d854',      // Yellow-green
+    'HAMAP': '#ffd92f',      // Yellow
+    'ProSiteProfiles': '#e5c494',  // Tan
+    'ProSitePatterns': '#b3b3b3',  // Light gray
+    'PRINTS': '#80b1d3',     // Sky blue
+    'PANTHER': '#fb8072',    // Salmon
+    'Gene3D': '#bebada',     // Lavender
+    'PIRSF': '#8dd3c7',      // Mint
+    'SUPERFAMILY': '#bc80bd', // Purple
+    'NCBIfam': '#ccebc5',    // Pale green
+    'default': '#999999'     // Gray
+  };
+
+  // External database URL patterns
+  var externalUrls = {
+    'CDD': 'https://www.ncbi.nlm.nih.gov/Structure/cdd/{id}',
+    'InterPro': 'https://www.ebi.ac.uk/interpro/entry/InterPro/{id}',
+    'Pfam': 'https://www.ebi.ac.uk/interpro/entry/pfam/{id}',
+    'SMART': 'http://smart.embl-heidelberg.de/smart/do_annotation.pl?ACC={id}',
+    'TIGRFAM': 'https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/{id}',
+    'HAMAP': 'https://hamap.expasy.org/rule/{id}',
+    'ProSiteProfiles': 'https://prosite.expasy.org/{id}',
+    'ProSitePatterns': 'https://prosite.expasy.org/{id}',
+    'PRINTS': 'http://www.bioinf.manchester.ac.uk/cgi-bin/dbbrowser/sprint/searchprintss.cgi?prints_accn={id}',
+    'PANTHER': 'http://www.pantherdb.org/panther/family.do?clsAccession={id}',
+    'Gene3D': 'http://www.cathdb.info/superfamily/{id}',
+    'PIRSF': 'https://proteininformationresource.org/cgi-bin/ipcSF?id={id}',
+    'SUPERFAMILY': 'https://supfam.org/SUPERFAMILY/cgi-bin/scop.cgi?ipid={id}',
+    'NCBIfam': 'https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/{id}'
+  };
+
+  return {
+    /**
+     * Get the color for a given domain source
+     * @param {string} source - The domain source name (e.g., 'CDD', 'InterPro')
+     * @returns {string} Hex color code
+     */
+    getSourceColor: function (source) {
+      if (!source) {
+        return sourceColors['default'];
+      }
+      // Try exact match first
+      if (sourceColors[source]) {
+        return sourceColors[source];
+      }
+      // Try case-insensitive match
+      var lowerSource = source.toLowerCase();
+      for (var key in sourceColors) {
+        if (key.toLowerCase() === lowerSource) {
+          return sourceColors[key];
+        }
+      }
+      return sourceColors['default'];
+    },
+
+    /**
+     * Get a darker shade of a hex color (for hover/selection states)
+     * @param {string} hexColor - Hex color code (e.g., '#66c2a5')
+     * @param {number} percent - Percentage to darken (0-100)
+     * @returns {string} Darker hex color code
+     */
+    getDarkerShade: function (hexColor, percent) {
+      percent = percent || 20;
+      var hex = hexColor.replace('#', '');
+      var r = parseInt(hex.substring(0, 2), 16);
+      var g = parseInt(hex.substring(2, 4), 16);
+      var b = parseInt(hex.substring(4, 6), 16);
+
+      r = Math.max(0, Math.floor(r * (100 - percent) / 100));
+      g = Math.max(0, Math.floor(g * (100 - percent) / 100));
+      b = Math.max(0, Math.floor(b * (100 - percent) / 100));
+
+      return '#' +
+        ('0' + r.toString(16)).slice(-2) +
+        ('0' + g.toString(16)).slice(-2) +
+        ('0' + b.toString(16)).slice(-2);
+    },
+
+    /**
+     * Get a lighter shade of a hex color (for backgrounds)
+     * @param {string} hexColor - Hex color code (e.g., '#66c2a5')
+     * @param {number} percent - Percentage to lighten (0-100)
+     * @returns {string} Lighter hex color code
+     */
+    getLighterShade: function (hexColor, percent) {
+      percent = percent || 30;
+      var hex = hexColor.replace('#', '');
+      var r = parseInt(hex.substring(0, 2), 16);
+      var g = parseInt(hex.substring(2, 4), 16);
+      var b = parseInt(hex.substring(4, 6), 16);
+
+      r = Math.min(255, Math.floor(r + (255 - r) * percent / 100));
+      g = Math.min(255, Math.floor(g + (255 - g) * percent / 100));
+      b = Math.min(255, Math.floor(b + (255 - b) * percent / 100));
+
+      return '#' +
+        ('0' + r.toString(16)).slice(-2) +
+        ('0' + g.toString(16)).slice(-2) +
+        ('0' + b.toString(16)).slice(-2);
+    },
+
+    /**
+     * Get the external database URL for a domain
+     * @param {string} source - The domain source name
+     * @param {string} sourceId - The source-specific ID
+     * @returns {string|null} External URL or null if not available
+     */
+    getExternalUrl: function (source, sourceId) {
+      if (!source || !sourceId) {
+        return null;
+      }
+      var urlPattern = externalUrls[source];
+      if (!urlPattern) {
+        // Try case-insensitive match
+        var lowerSource = source.toLowerCase();
+        for (var key in externalUrls) {
+          if (key.toLowerCase() === lowerSource) {
+            urlPattern = externalUrls[key];
+            break;
+          }
+        }
+      }
+      if (urlPattern) {
+        return urlPattern.replace('{id}', encodeURIComponent(sourceId));
+      }
+      return null;
+    },
+
+    /**
+     * Get all available source colors for legend display
+     * @returns {Object} Map of source names to colors (excluding 'default')
+     */
+    getAllSourceColors: function () {
+      var colors = {};
+      for (var key in sourceColors) {
+        if (key !== 'default') {
+          colors[key] = sourceColors[key];
+        }
+      }
+      return colors;
+    },
+
+    /**
+     * Get unique sources from a list of domains with their colors
+     * @param {Array} domains - Array of domain objects with 'source' property
+     * @returns {Array} Array of {source, color} objects for domains that have data
+     */
+    getSourcesFromDomains: function (domains) {
+      var seen = {};
+      var sources = [];
+      var self = this;
+
+      if (!domains || !domains.length) {
+        return sources;
+      }
+
+      domains.forEach(function (domain) {
+        var source = domain.source;
+        if (source && !seen[source]) {
+          seen[source] = true;
+          sources.push({
+            source: source,
+            color: self.getSourceColor(source)
+          });
+        }
+      });
+
+      // Sort alphabetically by source name
+      sources.sort(function (a, b) {
+        return a.source.localeCompare(b.source);
+      });
+
+      return sources;
+    }
+  };
+});

--- a/public/js/p3/widget/viewer/DomainVisualizationPanel.js
+++ b/public/js/p3/widget/viewer/DomainVisualizationPanel.js
@@ -1,0 +1,246 @@
+define([
+  'dojo/_base/declare', 'dojo/_base/lang',
+  'dojo/on', 'dojo/topic',
+  'dojo/dom-class', 'dojo/dom-construct', 'dojo/dom-style',
+  'dijit/layout/ContentPane',
+  './D3DomainViewer'
+], function (
+  declare, lang,
+  on, Topic,
+  domClass, domConstruct, domStyle,
+  ContentPane,
+  D3DomainViewer
+) {
+
+  /**
+   * DomainVisualizationPanel - A collapsible panel container for the D3DomainViewer
+   * Extends ContentPane to work properly within BorderContainer layouts.
+   */
+  return declare([ContentPane], {
+    // Configuration
+    title: 'Domain Map',
+    collapsed: false,
+    domainCount: 0,
+
+    // Region for BorderContainer - must be 'top' to appear above the grid
+    region: 'top',
+
+    // Panel sizing - set explicit height for BorderContainer, allow vertical scrolling
+    style: 'height: 250px; overflow-y: auto; overflow-x: hidden; padding: 0;',
+
+    // DOM nodes for our content
+    headerNode: null,
+    titleNode: null,
+    countNode: null,
+    toggleButton: null,
+    viewerContainer: null,
+
+    // Internal state
+    viewer: null,
+    domains: null,
+    proteinLength: 0,
+
+    constructor: function (args) {
+      lang.mixin(this, args || {});
+    },
+
+    postCreate: function () {
+      this.inherited(arguments);
+
+      // Add our CSS class
+      domClass.add(this.domNode, 'domain-visualization-panel');
+
+      // Create the panel content
+      this._createContent();
+    },
+
+    startup: function () {
+      this.inherited(arguments);
+
+      // Initialize the D3 viewer after DOM is ready
+      if (!this.viewer) {
+        this.viewer = new D3DomainViewer();
+        this.viewer.init(this.viewerContainer);
+      }
+
+      // Set up event handlers
+      this._setupEventHandlers();
+
+      // Subscribe to data events
+      this._subscribeToDataEvents();
+    },
+
+    /**
+     * Create the content structure for the panel
+     */
+    _createContent: function () {
+      // Header
+      this.headerNode = domConstruct.create('div', {
+        'class': 'domain-visualization-header'
+      }, this.containerNode || this.domNode);
+
+      // Title
+      this.titleNode = domConstruct.create('span', {
+        'class': 'domain-visualization-title',
+        innerHTML: this.title
+      }, this.headerNode);
+
+      // Count
+      this.countNode = domConstruct.create('span', {
+        'class': 'domain-visualization-count'
+      }, this.headerNode);
+
+      // Toggle button
+      this.toggleButton = domConstruct.create('button', {
+        'class': 'domain-visualization-toggle',
+        title: 'Toggle domain map',
+        innerHTML: '<i class="fa fa-chevron-up"></i>'
+      }, this.headerNode);
+
+      // Viewer container
+      this.viewerContainer = domConstruct.create('div', {
+        'class': 'domain-visualization-viewer'
+      }, this.containerNode || this.domNode);
+    },
+
+    /**
+     * Set up UI event handlers
+     */
+    _setupEventHandlers: function () {
+      var self = this;
+
+      // Toggle button click
+      if (this.toggleButton) {
+        on(this.toggleButton, 'click', function () {
+          self.toggle();
+        });
+      }
+
+      // Window resize
+      on(window, 'resize', lang.hitch(this, function () {
+        if (!this.collapsed && this.viewer) {
+          this.viewer.resize();
+        }
+      }));
+    },
+
+    /**
+     * Subscribe to data update events
+     */
+    _subscribeToDataEvents: function () {
+      var self = this;
+
+      // Listen for domain data updates from grid
+      Topic.subscribe('/domainGrid/dataLoaded', function (data) {
+        if (data && data.domains) {
+          self.setData(data.domains, data.proteinLength);
+        }
+      });
+
+      // Listen for grid filter changes
+      Topic.subscribe('/domainGrid/filtered', function (data) {
+        if (data && data.domains) {
+          self.setData(data.domains, data.proteinLength);
+        }
+      });
+    },
+
+    /**
+     * Set domain data and render
+     * @param {Array} domains - Array of domain objects
+     * @param {number} proteinLength - Length of the protein sequence
+     */
+    setData: function (domains, proteinLength) {
+      this.domains = domains || [];
+      this.proteinLength = proteinLength || 0;
+      this.domainCount = this.domains.length;
+
+      // Update count display
+      this._updateCountDisplay();
+
+      // Render visualization if not collapsed
+      if (!this.collapsed && this.viewer) {
+        this.viewer.setData(this.domains, this.proteinLength);
+      }
+    },
+
+    /**
+     * Update the domain count display
+     */
+    _updateCountDisplay: function () {
+      if (this.countNode) {
+        this.countNode.textContent = '(' + this.domainCount + ' domain' + (this.domainCount !== 1 ? 's' : '') + ')';
+      }
+    },
+
+    /**
+     * Toggle panel collapsed/expanded state
+     */
+    toggle: function () {
+      this.collapsed = !this.collapsed;
+
+      if (this.collapsed) {
+        domClass.add(this.domNode, 'collapsed');
+        domStyle.set(this.viewerContainer, 'display', 'none');
+        domStyle.set(this.domNode, 'height', '36px'); // Just header height
+        if (this.toggleButton) {
+          this.toggleButton.innerHTML = '<i class="fa fa-chevron-down"></i>';
+        }
+      } else {
+        domClass.remove(this.domNode, 'collapsed');
+        domStyle.set(this.viewerContainer, 'display', 'block');
+        domStyle.set(this.domNode, 'height', '250px'); // Expanded height
+        if (this.toggleButton) {
+          this.toggleButton.innerHTML = '<i class="fa fa-chevron-up"></i>';
+        }
+        // Re-render on expand
+        if (this.viewer && this.domains) {
+          this.viewer.setData(this.domains, this.proteinLength);
+        }
+      }
+
+      // Trigger layout recalculation in parent BorderContainer
+      if (this.getParent && this.getParent() && this.getParent().resize) {
+        this.getParent().resize();
+      }
+    },
+
+    /**
+     * Expand the panel
+     */
+    expand: function () {
+      if (this.collapsed) {
+        this.toggle();
+      }
+    },
+
+    /**
+     * Collapse the panel
+     */
+    collapse: function () {
+      if (!this.collapsed) {
+        this.toggle();
+      }
+    },
+
+    /**
+     * Set selection from external source (e.g., grid)
+     * @param {Array} ids - Array of selected domain IDs
+     */
+    setSelection: function (ids) {
+      if (this.viewer) {
+        this.viewer.setSelection(ids);
+      }
+    },
+
+    /**
+     * Resize the viewer
+     */
+    resize: function () {
+      this.inherited(arguments);
+      if (!this.collapsed && this.viewer) {
+        this.viewer.resize();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fix overlapping domains in the domain visualization by increasing max tracks from 8 to 15
- Reduce track height and padding to keep the visualization compact with more tracks
- Fix track assignment algorithm that was incorrectly comparing pixel padding with sequence coordinates

## Test plan
- Navigate to a feature with many domains (e.g., /view/Feature/PATRIC.2697049.107626.NC_045512.mat_peptide.2720.8554.fwd#view_tab=proteinFeatures)
- Verify that overlapping domains (like cd21557 at 236-359 and PF01661 at 240-346) are displayed on separate tracks
- Verify the visualization remains readable and compact

Fixes: https://github.com/BV-BRC/issues/issues/1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)